### PR TITLE
Enable support for .pcss extension

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ class LaravelMixPostCssConfigPlugin {
     return {
       rules: [
         {
-          test: /\.css/,
+          test: /\.(css|pcss)/,
           use: [{ loader: "postcss-loader", options: this.options }]
         }
       ]


### PR DESCRIPTION
.pcss is a popular extension for PostCSS files, endorsed by the PostCSS maintainers.